### PR TITLE
debian: no longer invokes dh_install manually

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,2 @@
+bps usr/share
+config.ini etc/bps

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,3 @@ export PYBUILD_NAME = autodidact
 
 %:
 	dh $@ --with python2 --with apache2 --buildsystem=pybuild
-
-override_dh_install:
-	dh_install bps /usr/share
-	dh_install config.ini /etc/bps # TODO: use conffiles or similar


### PR DESCRIPTION
Configfiles are automatically marked as such because the files end up in /etc.